### PR TITLE
prep-release-notes: update H1 markup to H2

### DIFF
--- a/prep-release-notes.py
+++ b/prep-release-notes.py
@@ -85,19 +85,19 @@ def main():
             }
 
     print('''\
-# Zephyr
+## Zephyr
 
 {}
 
-# MCUboot
+## MCUboot
 
 {}
 
-# dm-hawkbit-mqtt
+## dm-hawkbit-mqtt
 
 {}
 
-# dm-lwm2m
+## dm-lwm2m
 
 {}
 '''.format(*[notes_metadata[p]['changes'] for p in projects]))


### PR DESCRIPTION
This allows the release notes to land better on the website.

Signed-off-by: Michael Scott <mike@foundries.io>