### PR TITLE
prep-release-notes: reverse order of dm-* samples

### DIFF
--- a/prep-release-notes.py
+++ b/prep-release-notes.py
@@ -93,11 +93,11 @@ def main():
 
 {}
 
-## dm-hawkbit-mqtt
+## dm-lwm2m
 
 {}
 
-## dm-lwm2m
+## dm-hawkbit-mqtt
 
 {}
 '''.format(*[notes_metadata[p]['changes'] for p in projects]))


### PR DESCRIPTION
The processing array shows this order:
projects = ['zephyr', 'mcuboot', 'dm-lwm2m', 'dm-hawkbit-mqtt']

But the headers showed the last 2 projects in the wrong order.

Signed-off-by: Michael Scott <mike@foundries.io>